### PR TITLE
fix: data race on shouldContinue

### DIFF
--- a/.github/workflows/build.yaml.yml
+++ b/.github/workflows/build.yaml.yml
@@ -24,7 +24,7 @@ jobs:
           go-version-file: go.mod
       - run: go mod download
       - run: make generate
-      - run: go test -tags=integration ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./...
+      - run: go test -race -tags=integration ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./...
       - name: sonarcloud-scan
         uses: sonarsource/sonarqube-scan-action@v6
         if: false # skip until fix token issues

--- a/core.go
+++ b/core.go
@@ -11,7 +11,7 @@ func (c *core[MessageType]) Run(processor Processor[MessageType]) {
 		return processor(ctx, item)
 	}))
 
-	for c.shouldContinue {
+	for c.shouldContinue.Load() {
 		ctx := context.Background()
 		c.resultsObserver(c.chain.Process(ctx, nil))
 	}
@@ -24,13 +24,15 @@ func (c *core[MessageType]) AddMiddleware(middleware Middleware[*MessageType]) M
 }
 
 func (c *core[MessageType]) Stop() {
-	c.shouldContinue = false
+	c.shouldContinue.Store(false)
 }
 
 func New[MessageType any](resultsObserver func(error)) MessageProcessor[MessageType] {
-	return &core[MessageType]{
+	instance := &core[MessageType]{
 		chain:           middleware.New[*MessageType, error](),
-		shouldContinue:  true,
 		resultsObserver: resultsObserver,
 	}
+	instance.shouldContinue.Store(true)
+
+	return instance
 }

--- a/middlewares/gracefulshutdown/shutdown_test.go
+++ b/middlewares/gracefulshutdown/shutdown_test.go
@@ -3,6 +3,7 @@ package gracefulshutdown_test
 import (
 	"context"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -42,7 +43,7 @@ func TestMiddleware(t *testing.T) {
 
 		middleware := gracefulshutdown.MiddlewareWithStopSignalChannel[int](signalCh, mockCore)
 
-		called := false
+		var called atomic.Bool
 
 		// Start Process in a goroutine so we can send the "signal"
 		go func() {
@@ -50,7 +51,7 @@ func TestMiddleware(t *testing.T) {
 			err := middleware.Process(t.Context(), &item, func(ctx context.Context, item *int) error {
 				<-ctx.Done() // wait for cancellation
 
-				called = true
+				called.Store(true)
 
 				return ctx.Err()
 			})
@@ -62,6 +63,6 @@ func TestMiddleware(t *testing.T) {
 
 		time.Sleep(50 * time.Millisecond) // give goroutine a moment to react
 
-		assert.True(t, called)
+		assert.True(t, called.Load())
 	})
 }

--- a/types.go
+++ b/types.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/messaging-go/core/internal/middleware"
 )
@@ -12,7 +13,7 @@ type Middleware[T any] interface {
 
 type core[MessageType any] struct {
 	chain           middleware.Processor[*MessageType, error]
-	shouldContinue  bool
+	shouldContinue  atomic.Bool
 	resultsObserver func(error)
 }
 type Processor[MessageType any] func(ctx context.Context, item *MessageType) error


### PR DESCRIPTION


## Pull Request Checklist

Please confirm that you have done the following:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to
  the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
- [x] I have added tests for all code changes.

Link to documentation changes:
### Description
  - `core.shouldContinue` promoted from plain `bool` to `sync/atomic.Bool`. `Run()` uses `Load()`, `Stop()` uses `Store(false)`. Public API is unchanged, so the backwards-compat guarantee in `CONTRIBUTING.md` holds.
  - Pre-existing race in `middlewares/gracefulshutdown/shutdown_test.go` fixed: the `called` flag is now `atomic.Bool`, so the write from the middleware goroutine and the read from the assertion are synchronized. Unrelated to       
  production behavior, but it surfaces once `-race` is enabled in CI.                                                                                                                                                            
  - CI test step updated to pass `-race`, so regressions in this class of bug are caught automatically.


closes #5
